### PR TITLE
add pageview_id to events table

### DIFF
--- a/db/migrate/20200103012916_create_land_schema.rb
+++ b/db/migrate/20200103012916_create_land_schema.rb
@@ -196,6 +196,7 @@ class CreateLandSchema < ActiveRecord::Migration[5.0]
 
         , event_type_id SMALLINT    NOT NULL REFERENCES event_types
         , visit_id      UUID        NOT NULL REFERENCES visits
+        , pageview_id   UUID                 REFERENCES pageviews
 
         , meta          JSON
 
@@ -204,6 +205,7 @@ class CreateLandSchema < ActiveRecord::Migration[5.0]
 
       CREATE INDEX ON events (event_type_id);
       CREATE INDEX ON events (visit_id);
+      CREATE INDEX ON events (pageview_id);
 
 
       INSERT INTO bid_match_types (bid_match_type) VALUES ('bidded broad'), ('bidded content'), ('bidded exact'), ('bidded phrase');

--- a/lib/land/trackers/user_tracker.rb
+++ b/lib/land/trackers/user_tracker.rb
@@ -45,7 +45,7 @@ module Land
           p.response_time = (current_time - @start_time) * 1000
         end
       end
-
+      
       def save
         record_pageview
 

--- a/spec/internal/db/structure.sql
+++ b/spec/internal/db/structure.sql
@@ -510,6 +510,7 @@ CREATE TABLE land.events (
     event_id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
     event_type_id smallint NOT NULL,
     visit_id uuid NOT NULL,
+    pageview_id uuid,
     meta json,
     created_at timestamp with time zone DEFAULT now() NOT NULL
 );
@@ -2097,6 +2098,13 @@ CREATE INDEX events_event_type_id_idx ON land.events USING btree (event_type_id)
 
 
 --
+-- Name: events_pageview_id_idx; Type: INDEX; Schema: land; Owner: -
+--
+
+CREATE INDEX events_pageview_id_idx ON land.events USING btree (pageview_id);
+
+
+--
 -- Name: events_visit_id_idx; Type: INDEX; Schema: land; Owner: -
 --
 
@@ -2515,6 +2523,14 @@ ALTER TABLE ONLY land.attributions
 
 ALTER TABLE ONLY land.events
     ADD CONSTRAINT events_event_type_id_fkey FOREIGN KEY (event_type_id) REFERENCES land.event_types(event_type_id);
+
+
+--
+-- Name: events events_pageview_id_fkey; Type: FK CONSTRAINT; Schema: land; Owner: -
+--
+
+ALTER TABLE ONLY land.events
+    ADD CONSTRAINT events_pageview_id_fkey FOREIGN KEY (pageview_id) REFERENCES land.pageviews(pageview_id);
 
 
 --

--- a/spec/land/action_spec.rb
+++ b/spec/land/action_spec.rb
@@ -58,6 +58,7 @@ module Land
         # expect(pageview.request_id).to eq uuid
       end
 
+
       it 'tracks referers' do
         request.headers['HTTP_REFERER'] = "https://google.com/results?q=needle"
 
@@ -245,6 +246,14 @@ module Land
           expect(Attribution.last.source).to eq value
         end
       end
+    end
+
+    it 'tracks events' do
+      EventType.create(event_type: 'test')
+
+      get :test
+      
+      expect { Event.create(visit_id: Visit.last.id, event_type: 'test', pageview_id: Pageview.last.id) }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
BUG FIX:  https://trello.com/c/FlBkIb1J/440-landevents-missing-pageviewid-foreign-key