### PR TITLE
441 when referer omits trailing slash from top level, assume root path

### DIFF
--- a/lib/land/tracker.rb
+++ b/lib/land/tracker.rb
@@ -171,7 +171,7 @@ module Land
 
       begin
         @referer = Referer.where(domain_id:       Domain[referer_uri.host],
-                                 path_id:         Path[referer_uri.path],
+                                 path_id:         Path[referer_path],
                                  query_string_id: QueryString[query.to_query],
                                  attribution_id:  attribution.id).first_or_create
       rescue ActiveRecord::RecordNotUnique
@@ -181,6 +181,10 @@ module Land
 
     def referer_changed?
       external_referer? && referer_hash != @referer_hash
+    end
+
+    def referer_path
+      referer_uri.path.present? ? referer_uri.path : '/'
     end
 
     def referer_uri


### PR DESCRIPTION
https://trello.com/c/2dtlzH7A/441-postgres-not-null-constraint-on-pathid-fails-on-writing-referer

Originally I was thinking that dropping the not null path constraint might be the way to go, but after more observation, I saw that browser-based nav often had referers come in as `https://whatever.com/` which translated to a `/` path and saved it in current code.

So it felt better to normalize the handling here and if we get a value without the trailing slash, call the path root anyway ... so `https://whatever.com/` tracks the same as `https://whatever.com` with respect to referer.

My gut here is that we're seeing this a bunch from `https://m.facebook.com` (👈 no trailing slash) as a result of people clicking from the facebook app. From what I saw iOs safari appended the slash, but it's overwhelmingly that facebook domain from iOs that's giving us the error.

I red-greened this test too, so I feel pretty confident about this for the path_id issue. visit_id will still be out there for now.