### PR TITLE
Removes deprecated method

### DIFF
--- a/lib/land/tracker.rb
+++ b/lib/land/tracker.rb
@@ -184,7 +184,7 @@ module Land
     end
 
     def referer_uri
-      @referer_uri ||= URI(URI.encode(request.referer)) if request.referer
+      @referer_uri ||= URI(request.referer) if request.referer
     end
 
     def attribution

--- a/spec/land/action_spec.rb
+++ b/spec/land/action_spec.rb
@@ -59,7 +59,7 @@ module Land
       end
 
       it 'tracks referers' do
-        request.headers['HTTP_REFERER'] = "https://google.com/results?q=needle"
+        request.headers['HTTP_REFERER'] = "https://google.com/results?q=needle foo"
 
         get :test
 
@@ -69,7 +69,7 @@ module Land
 
         expect(visit.referer.domain).to       eq "google.com"
         expect(visit.referer.path).to         eq "/results"
-        expect(visit.referer.query_string).to eq "q=needle"
+        expect(visit.referer.query_string).to eq "q=needle+foo"
       end
 
       it 'sets cookies' do


### PR DESCRIPTION
Trello: https://trello.com/c/N7cRe3cO/578-fix-uriescape-deprecation-in-land-gem