### PR TITLE
Update Path lookup model to allow blank path

### DIFF
--- a/app/lookups/land/path.rb
+++ b/app/lookups/land/path.rb
@@ -2,7 +2,7 @@ module Land
   class Path < ApplicationRecord
     include TableName
 
-    lookup_by :path, cache: 50, find_or_create: true
+    lookup_by :path, cache: 50, find_or_create: true, allow_blank: true
 
     has_many :page_views
     has_many :referers

--- a/spec/land/action_spec.rb
+++ b/spec/land/action_spec.rb
@@ -58,7 +58,6 @@ module Land
         # expect(pageview.request_id).to eq uuid
       end
 
-
       it 'tracks referers' do
         request.headers['HTTP_REFERER'] = "https://google.com/results?q=needle foo"
 
@@ -71,6 +70,15 @@ module Land
         expect(visit.referer.domain).to       eq "google.com"
         expect(visit.referer.path).to         eq "/results"
         expect(visit.referer.query_string).to eq "q=needle+foo"
+      end
+
+      it 'tracks referers with no path' do
+        request.headers['HTTP_REFERER'] = 'http://m.facebook.com'
+        get :test
+        expect(controller.land.visit.referer).to have_attributes(
+          domain: 'm.facebook.com',
+          path: ''
+        )
       end
 
       it 'sets cookies' do


### PR DESCRIPTION
https://trello.com/c/KR2Ymrp1/608-not-null-constraint-on-pathid-for-land

We are getting referer headers without any path which causes errors while trying to save referer.  Update to allow blank path (empty string).