### PR TITLE
Handle referer header that are blank or without scheme

### DIFF
--- a/lib/land/tracker.rb
+++ b/lib/land/tracker.rb
@@ -170,7 +170,7 @@ module Land
       query       = params.except(*ATTRIBUTION_KEYS)
 
       begin
-        @referer = Referer.where(domain_id:       Domain[referer_uri.host],
+        @referer = Referer.where(domain_id:       Domain[referer_uri.host.to_s],
                                  path_id:         Path[referer_uri.path],
                                  query_string_id: QueryString[query.to_query],
                                  attribution_id:  attribution.id).first_or_create
@@ -184,7 +184,7 @@ module Land
     end
 
     def referer_uri
-      @referer_uri ||= URI(request.referer) if request.referer
+      @referer_uri ||= URI(request.referer.sub(/\Awww\./i, '//\0')) if request.referer.present?
     end
 
     def attribution

--- a/spec/land/action_spec.rb
+++ b/spec/land/action_spec.rb
@@ -73,6 +73,51 @@ module Land
         expect(visit.referer.query_string).to eq "q=needle+foo"
       end
 
+      it 'tracks referers without scheme and starts with www' do
+        request.headers['HTTP_REFERER'] = "www.google.com/results?q=needle foo"
+
+        get :test
+
+        visit = controller.land.visit
+
+        expect(visit).to be_persisted
+
+        expect(Referer.count).to eq 1
+
+        expect(visit.referer.domain).to       eq "www.google.com"
+        expect(visit.referer.path).to         eq "/results"
+        expect(visit.referer.query_string).to eq "q=needle+foo"
+      end
+
+      it 'tracks invalid referers' do
+        request.headers['HTTP_REFERER'] = "path/results?q=needle foo"
+
+        get :test
+
+        visit = controller.land.visit
+
+        expect(visit).to be_persisted
+
+        expect(Referer.count).to eq 1
+
+        expect(visit.referer.domain).to       eq ""
+        expect(visit.referer.path).to         eq "path/results"
+        expect(visit.referer.query_string).to eq "q=needle+foo"
+      end
+
+      it 'does not track blank referer' do
+        request.headers['HTTP_REFERER'] = "   \t"
+
+        get :test
+
+        visit = controller.land.visit
+
+        expect(visit).to be_persisted
+
+        expect(Referer.count).to eq 0
+        expect(visit.referer).to be nil
+      end
+
       it 'sets cookies' do
         expect { get :test }.to change { Cookie.count }.by 1
 


### PR DESCRIPTION
https://trello.com/c/KzRUSR9e/487-postgres-not-null-constraint-on-visitid-fails-on-writing-pageview

https://github.com/Beyond-Finance/accredited-debt-relief/pull/284

#### notes on testing
* Adjust Referer header for the following scenarios (logs should not contain any errors in saving referer or visit)
    * blank (couple of spaces) - no visit.referer is created
    * www.google.com - referer is created (saved in domain)
    * test-test - referer is created (saved in path)