### PR TITLE
Track request_id on land.events table

### DIFF
--- a/db/migrate/20201024041516_events_request_id.rb
+++ b/db/migrate/20201024041516_events_request_id.rb
@@ -1,0 +1,17 @@
+class EventsRequestId < ActiveRecord::Migration[6.0]
+  def change
+    add_column 'land.events', :request_id, :uuid
+
+    execute <<-SQL
+      UPDATE land.events e
+      SET
+        request_id = p.request_id
+      FROM land.events e1
+        JOIN land.pageviews p using (pageview_id)
+      WHERE
+        e.pageview_id = p.pageview_id
+        AND p.request_id IS NOT NULL
+        AND e1.request_id IS NULL
+    SQL
+  end
+end

--- a/db/migrate/20201027042604_events_request_id_index.rb
+++ b/db/migrate/20201027042604_events_request_id_index.rb
@@ -1,0 +1,7 @@
+class EventsRequestIdIndex < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index 'land.events', :request_id, algorithm: :concurrently
+  end
+end

--- a/lib/land/tracker.rb
+++ b/lib/land/tracker.rb
@@ -123,7 +123,7 @@ module Land
     def queue_event(type, meta = {})
       return unless tracking?
 
-      Event.new(visit_id: @visit_id, event_type: type, meta: meta).tap do |event|
+      Event.new(visit_id: @visit_id, event_type: type, meta: meta, request_id: request.uuid).tap do |event|
         @events << event
       end
     end

--- a/spec/internal/app/controllers/pages_controller.rb
+++ b/spec/internal/app/controllers/pages_controller.rb
@@ -1,0 +1,8 @@
+class PagesController < ActionController::Base
+  def index
+    Land::EventType.find_or_create_by(event_type: 'test')
+
+    @land.queue_event('test', {foo: :bar})
+    render plain: "200 OK"
+  end
+end

--- a/spec/internal/config/routes.rb
+++ b/spec/internal/config/routes.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  # Add your own routes here, or remove this file if you don't have need for it.
+  root to: 'pages#index'
 end

--- a/spec/internal/db/structure.sql
+++ b/spec/internal/db/structure.sql
@@ -512,7 +512,8 @@ CREATE TABLE land.events (
     visit_id uuid NOT NULL,
     pageview_id uuid,
     meta json,
-    created_at timestamp with time zone DEFAULT now() NOT NULL
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    request_id uuid
 );
 
 
@@ -2126,6 +2127,13 @@ CREATE UNIQUE INDEX http_methods__u_http_method ON land.http_methods USING btree
 
 
 --
+-- Name: index_land.events_on_request_id; Type: INDEX; Schema: land; Owner: -
+--
+
+CREATE INDEX "index_land.events_on_request_id" ON land.events USING btree (request_id);
+
+
+--
 -- Name: keywords__u_keyword; Type: INDEX; Schema: land; Owner: -
 --
 
@@ -2708,6 +2716,8 @@ ALTER TABLE ONLY land.visits
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
-('20200103012916');
+('20200103012916'),
+('20201024041516'),
+('20201027042604');
 
 

--- a/spec/land/action_spec.rb
+++ b/spec/land/action_spec.rb
@@ -53,9 +53,6 @@ module Land
         expect(pageview.path).to eq "/test"
         expect(pageview.query_string).to be_blank
         expect(pageview.http_status).to  eq 200
-
-        # @todo is combustion running the ActionDispatch::RequestId middleware?
-        # expect(pageview.request_id).to eq uuid
       end
 
       context 'when tracking referers' do

--- a/spec/land/request_spec.rb
+++ b/spec/land/request_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Land
+  describe 'Requests', type: :request do
+    before do
+      get root_path
+    end
+
+    context 'for pageviews' do
+      it 'records request id' do
+        expect(Land::Pageview.last.request_id).to eql(response.request.request_id)
+      end
+    end
+
+    context 'for events' do
+      it 'records request id' do
+        expect(Land::Event.last.request_id).to eql(response.request.request_id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Preparing for dropping pageview_id on land.events. Land events queued up
to be saved should be able to be saved regardless of whether there was an
error on the page. Currently, they're getting dropped on the floor in
the event of a 500 because after filters no longer run.

If we drop pageview_id and instead tie pageviews via request_id, then we
can save land events inline instead of waiting until after the request.

https://trello.com/c/c10WxipV