### PR TITLE
add missing events.pageview_id migration

### DIFF
--- a/db/migrate/20200724201945_add_pageview_id_to_events.rb
+++ b/db/migrate/20200724201945_add_pageview_id_to_events.rb
@@ -1,0 +1,14 @@
+class AddPageviewIdToEvents < ActiveRecord::Migration[6.0]
+  def change
+    conn = ActiveRecord::Base.connection
+    old_search_path = conn.schema_search_path
+    conn.execute "SET search_path TO land, #{conn.schema_search_path}"
+    
+    unless column_exists? :events, :pageview_id
+      add_column :events, :pageview_id, :uuid
+      add_foreign_key :events, :pageviews, column: :pageview_id, primary_key: :pageview_id
+    end
+
+    conn.execute "SET search_path TO #{old_search_path}"
+  end
+end

--- a/spec/internal/db/structure.sql
+++ b/spec/internal/db/structure.sql
@@ -2717,6 +2717,7 @@ SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
 ('20200103012916'),
+('20200724201945'),
 ('20201024041516'),
 ('20201027042604');
 


### PR DESCRIPTION
Soo.....It's totally weird that we have apps that are missing
events.pageview_id, but its in the schema for the land gem. How did we
lose it everywhere else? Who was phone?