### PR TITLE
3197 investigate activerecordnotnullviolation error in adr

### DIFF
--- a/land.gemspec
+++ b/land.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^exe/}) { |f| File.basename(f) }
   gem.require_paths = ["lib"]
 
+  gem.add_dependency "addressable"
   gem.add_dependency "activerecord", " > 4.0.0"
   gem.add_dependency "lookup_by",    "~> 0.11.0"
 

--- a/lib/land/tracker.rb
+++ b/lib/land/tracker.rb
@@ -188,7 +188,7 @@ module Land
     end
 
     def referer_uri
-      @referer_uri ||= URI(request.referer.sub(/\Awww\./i, '//\0')) if request.referer.present?
+      @referer_uri ||= Addressable::URI.parse(request.referer.sub(/\Awww\./i, '//\0')) if request.referer.present?)
     end
 
     def attribution

--- a/lib/land/tracker.rb
+++ b/lib/land/tracker.rb
@@ -188,7 +188,7 @@ module Land
     end
 
     def referer_uri
-      @referer_uri ||= Addressable::URI.parse(request.referer.sub(/\Awww\./i, '//\0')) if request.referer.present?)
+      @referer_uri ||= Addressable::URI.parse(request.referer.sub(/\Awww\./i, '//\0')) if request.referer.present?
     end
 
     def attribution

--- a/lib/land/tracker.rb
+++ b/lib/land/tracker.rb
@@ -2,6 +2,7 @@
 
 require "digest/sha2"
 require "uri"
+require "addressable/uri"
 
 module Land
   class Tracker


### PR DESCRIPTION
- Implemented in this [PR](https://github.com/Beyond-Finance/accredited-debt-relief/pull/861)
- Adds addressable gem to handle parsing incoming request.referers
- https://onenr.io/0BR6vzn7bRO
```
irb(main):005:0> url 
=> "https://trkac1.com/?a=133&c=15&campaign_id=871&utm_medium=affiliate&utm_source=133&utm_campaign=06-871&s1=#MBID#&s2=#ACID#&s3=#s1#"
irb(main):006:0> URI(url.sub(/\Awww\./i, '//\0'))
Traceback (most recent call last):
        1: from (irb):6
URI::InvalidURIError (bad URI(is not URI?): "https://trkac1.com/?a=133&c=15&campaign_id=871&utm_medium=affiliate&utm_source=133&utm_campaign=06-871&s1=#MBID#&s2=#ACID#&s3=#s1#")
irb(main):007:0> Addressable::URI.parse(url)
=> #<Addressable::URI:0x76c0 URI:https://trkac1.com/?a=133&c=15&campaign_id=871&utm_medium=affiliate&utm_source=133&utm_campaign=06-871&s1=#MBID#&s2=#ACID#&s3=#s1#>
irb(main):008:0> 
```