### PR TITLE
3305 visit_id error in ADR

### DIFF
--- a/lib/land/version.rb
+++ b/lib/land/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Land
-  VERSION = '0.1.4'
+  VERSION = '0.1.5'
 end


### PR DESCRIPTION
It doesn't seem like there's much we can do here other than try to make our bad input handling a little more bulletproof.

We have two errors going on here that are happening in about the same spot ...

# DCR

we're seeing a bad param value. Visit `/?affiliate_id=86&campaign_id=2226&device=../../../../../../../../etc/passwd%00&subid2=e&subid3=376621241&subid4=1225955688900081&subid5=&subid6=o`

Look at your logs, and see that you get these issues (they aren't right next to each other, they're separated by some activity, but one leads to the other):
```
11:49:42 web.1  |   Land::DeviceType Load (0.2ms)  SELECT "land"."device_types".* FROM "land"."device_types" WHERE "land"."device_types"."device_type" = $1 ORDER BY "land"."device_types"."device_type_id" ASC LIMIT $2  [["device_type", "../../../../../../../../etc/passwd\u0000"], ["LIMIT", 1]]
11:49:42 web.1  | string contains null byte
```
then later:
```
11:49:42 web.1  | PG::NotNullViolation: ERROR:  null value in column "visit_id" violates not-null constraint
11:49:42 web.1  | DETAIL:  Failing row contains (2258bbd0-f55d-4e71-90d9-d022f644f86b, null, 2, 3, null, 1, 88db8744-5f94-4840-88a5-89f207c7bdd5, null, 200, 775, 2022-05-24 16:49:42.694374+00).
```

The end user doesn't see this, but it is causing lots of noise in New Relic; update to this gem branch in `Gemfile`, `bundle install`, restart the server, hit the url again, and see that the above no longer occur.

# ADR

we're seeing occasional param overflow. So, visit something like [this link to localhost](http://localhost:3000/?content=\r\n\r\nLorem-ipsum-dolor-sit-amet,-consectetur-adipiscing-elit.-Maecenas-laoreet-risus-est,-vel-iaculis-diam-finibus-vel.-Aliquam-finibus-nibh-quis-ex-porta,-at-sollicitudin-dui-rhoncus.-Pellentesque-congue-eros-quis-sollicitudin-aliquet.-Praesent-ultricies-mauris-non-lorem-consectetur,-ut-viverra-ex-semper.-Integer-lacus-urna,-tempor-quis-luctus-vel,-congue-vitae-felis.-Pellentesque-eu-est-eget-sapien-consectetur-dapibus.-Fusce-nec-leo-nisi.-Donec-consequat-mi-enim,-accumsan-congue-mi-placerat-eu.-Nulla-ex-mi,-pulvinar-in-ornare-sit-amet,-sagittis-a-nisl.-Etiam-vitae-risus-lobortis,-pulvinar-purus-dictum,-tincidunt-dui.-Nulla-ullamcorper-laoreet-lectus,-eget-porta-erat-egestas-id.-In-eu-suscipit-arcu.\r\n\r\nNulla-ac-mauris-arcu.-Nam-ac-ligula-vel-nisl-imperdiet-convallis-at-et-lacus.-Curabitur-quis-eros-eu-ante-imperdiet-porta.-Donec-ut-consectetur-risus,-at-suscipit-ligula.-Vivamus-eu-consectetur-metus,-ac-tincidunt-nibh.-Aliquam-erat-volutpat.-Vestibulum-maximus-lorem-urna,-ut-congue-mi-lobortis-vitae.-Nunc-porttitor-velit-vel-quam-ullamcorper-dignissim.-Phasellus-id-metus-suscipit,-rutrum-metus-eu,-ullamcorper-urna.\r\n\r\nUt-auctor-vehicula-arcu.-Nulla-egestas-commodo-purus.-Nunc-faucibus-enim-leo,-et-luctus-libero-vestibulum-pharetra.-Donec-nec-ligula-sit-amet-ipsum-fermentum-malesuada.-Maecenas-vel-ornare-turpis.-Integer-ac-scelerisque-leo.-Praesent-eleifend-accumsan-est-id-rutrum.-Phasellus-purus-dolor,-dapibus-ac-sem-a,-hendrerit-pellentesque-arcu.-Integer-eget-urna-sed-tellus-imperdiet-elementum.-Aenean-metus-quam,-convallis-suscipit-justo-ut,-blandit-placerat-lectus.-Fusce-quis-est-ac-est-finibus-scelerisque-non-sit-amet-lectus.-Pellentesque-quis-egestas-dui,-ac-aliquam-nulla.-Nam-faucibus-sagittis-odio-nec-luctus.-Vivamus-quis-massa-dolor.-Fusce-ultricies-ex-lacus,-et-pharetra-ex-molestie-at.\r\n\r\nMaecenas-arcu-lacus,-pellentesque-et-viverra-ac,-aliquam-eu-ex.-Cras-vitae-turpis-sem.-Aliquam-ut-tortor-augue.-Etiam-et-mauris-a-lectus-pretium-ornare.-Quisque-dapibus-nulla-mi,-eget-ornare-nulla-porttitor-non.-Nam-aliquet-feugiat-felis,-eu-ornare-nunc-accumsan-a.-In-sit-amet-vulputate-tellus.-Proin-mollis-malesuada-sagittis.-In-elit-tellus,-tempor-ut-ligula-vel,-tristique-commodo-elit.\r\n\r\nPraesent-a-lectus-ut-ante-tristique-lobortis-at-eu-odio.-Praesent-rutrum-metus-at-pretium-volutpat.-Ut-ultrices-ac-odio-quis-porttitor.-Vestibulum-viverra-ut-tellus-venenatis-laoreet.-Nam-metus-justo,-ullamcorper-in-velit-vel,-dignissim-ultricies-nulla.-Ut-iaculis-neque-vel-pellentesque-aliquam.-In-eu-odio-sit-amet-justo-gravida-lacinia.-Mauris-pretium-semper-lorem-nec-tempor.-Praesent-ac-rutrum-justo.-Quisque-viverra-sed-neque-et-aliquam.-Integer-facilisis-sed-nulla-sed-imperdiet.-Morbi-eget-arcu-nisl.-Etiam-ex-sem,-cursus-quis-convallis-vel,-convallis-sit-amet-odio.\r\n\r\nDuis-in-sapien-mauris.-Aliquam-faucibus,-nisi-vel-interdum-lacinia,-enim-justo-elementum-ante,-at-consectetur-enim-lacus-vitae-mi.-Sed-rutrum-accumsan-nunc,-quis-mollis-est-sodales-sit-amet.-Nunc-vulputate-egestas-nisi,-in-efficitur-urna-ullamcorper-eu.-Morbi-ac-orci-rhoncus,-semper-magna-et,-egestas-dolor.-Proin-porta-bibendum-nulla,-eu-tincidunt-dui-consequat-nec.-Donec-vitae-venenatis-mi.\r\n\r\nMaecenas-dictum-sem-imperdiet-nulla-porttitor-lacinia.-Nunc-eu-viverra-tellus.-Proin-laoreet-cursus-nisi-id-pulvinar.-Nam-a-sem-commodo,-pellentesque-massa-nec,-convallis-risus.-Proin-nec-maximus-dolor.-Aenean-egestas,-massa-eu-gravida-pretium,-diam-massa-tempus-tellus,-dapibus-fermentum-augue-est-nec-turpis.-Curabitur-hendrerit-purus-eros.-Ut-aliquet-mollis-porta.-Aliquam-at-turpis-nibh.-Vestibulum-vitae-mauris-in-mauris-condimentum-aliquet.-Ut-sit-amet-nulla-lacus.-Fusce-faucibus-eget-velit-quis-posuere.-Proin-fermentum-justo-ligula,-ac-blandit-nibh-lacinia-vel.\r\n\r\nFusce-id-dictum-lectus.-Nunc-condimentum,-ipsum-a-ultrices-facilisis,-nisi-diam-sodales-dolor,-id-ornare-magna-diam-in-leo.-Donec-molestie-odio-ac-lorem-vestibulum-vulputate.-Aliquam-erat-volutpat.-Mauris-at-tortor-eget-diam-cursus-cursus.-Interdum-et-malesuada-fames-ac-ante-ipsum-primis-in-faucibus.-Nullam-id-lobortis-sapien.-Curabitur-posuere-vehicula-rutrum.-Quisque-accumsan-eros-quis-massa-porta-lobortis.\r\n\r\nIn-hac-habitasse-platea-dictumst.-Praesent-at-sollicitudin-nisi.-Morbi-tincidunt-diam-orci,-eget-rutrum-odio-sagittis-ac.-Curabitur-mattis-cursus-convallis.-Cras-ullamcorper-augue-eros,-at-suscipit-ex-tincidunt-a.-Nullam-in-ante-vitae-nibh-tincidunt-faucibus.-Nullam-eu-vulputate-ligula.-Fusce-nec-consequat-libero.-Morbi-at-fermentum-tortor,-ut-rutrum-dui.-Sed-fermentum-ipsum-et-risus-semper,-eu-pulvinar-risus-ornare.-Maecenas-vel-nunc-sodales,-faucibus-lectus-vel,-blandit-lacus.-Donec-accumsan-cursus-sapien,-ac-rutrum-massa-efficitur-gravida.\r\n\r\nNam-vel-posuere-nibh.-Etiam-dignissim-sollicitudin-lectus,-ac-ultricies-mi-aliquam-vel.-Phasellus-pulvinar-nulla-enim,-in-gravida-est-bibendum-vitae.-Etiam-pretium,-purus-feugiat-consectetur-cursus,-purus-nisl-vulputate-elit,-vel-bibendum-magna-arcu-non-sapien.-Etiam-quis-ipsum-vel-lectus-eleifend-lacinia-at-in-turpis.-Integer-efficitur-imperdiet-libero,-lobortis-egestas-velit-cursus-eget.-Nam-posuere-laoreet-urna.-Pellentesque-condimentum-nulla-et-elit-semper,-sit-amet-luctus-magna-ullamcorper.-Cras-varius-dapibus-justo-a-laoreet.-Aliquam-risus-sem,-fringilla-id-imperdiet-vel,-consequat-vitae-quam.-Maecenas-quam-odio,-egestas-vitae-risus-vitae,-faucibus-suscipit-mauris.-Mauris-mattis-mauris-sem,-ut-molestie-ipsum-sodales-sed.-Cras-pulvinar-blandit-eros-sed-efficitur.-Proin-sed-lectus-ut-mauris-accumsan-accumsan.-Integer-a-mauris-ultricies,-porttitor-elit-at,-accumsan-enim.-Nulla-vitae-metus-non-quam-ultrices-commodo-sit-amet-sed-magna.\r\n\r\nProin-maximus-sem-elit,-non-lacinia-lorem-elementum-quis.-Donec-nec-vestibulum-purus,-id-aliquam-lorem.-Curabitur-ut-cursus-massa.-Etiam-luctus-maximus-tellus-ac-efficitur.-Integer-id-turpis-non-justo-pellentesque-sodales.-Duis-metus-quam,-fringilla-ut-leo-sed,-porta-pretium-risus.-In-dignissim-erat-sed-tincidunt-sagittis.-Pellentesque-aliquet-nibh-eget-fermentum-porttitor.\r\n\r\nUt-diam-elit,-ullamcorper-eget-egestas-vitae,-sagittis-in-diam.-Phasellus-pretium-suscipit-eleifend.-Duis-sit-amet-efficitur-mi.-Praesent-sit-amet-aliquet-eros.-Mauris-rhoncus-auctor-nunc-eget-scelerisque.-Suspendisse-fermentum,-nisl-ut-scelerisque-lacinia,-nunc-mi-rhoncus-velit,-sit-amet-placerat-velit-nulla-venenatis-dui.-Phasellus-lacus-ipsum,-sodales-in-ex-sit-amet,-rhoncus-auctor-sapien.-Praesent-tempus-risus-non-urna-lobortis-ultrices.-Suspendisse-ornare-sit-amet-augue-sed-auctor.-Curabitur-quam-felis,-dictum-quis-tortor-vel,-vulputate-malesuada-felis.-Nulla-vestibulum-turpis-a-sem-posuere,-nec-malesuada-lacus-laoreet.-Nullam-scelerisque-condimentum-diam,-ac-fermentum-turpis.\r\n\r\nNulla-facilisi.-Ut-vestibulum-metus-sem,-id-varius-nulla-iaculis-vitae.-Proin-elit-nibh,-auctor-vel-lectus-vitae,-molestie-porttitor-magna.-Sed-ac-neque-quis-ante-venenatis-tincidunt-sit-amet-et-lorem.-Aliquam-sit-amet-tortor-volutpat,-varius-tortor-quis,-ornare-arcu.-Praesent-nec-sapien-eget-neque-aliquam-interdum-ut-a-ex.-Duis-in-sagittis-ligula.-Praesent-efficitur-risus-eu-risus-porttitor-porta.-Nam-id-risus-erat.-Suspendisse-commodo-augue-nec-tellus-rutrum-placerat.)

Look at your logs, and see that there are errors like these (again, separated from one another in the log, but related):
```
11:55:40 web.1  | PG::ProgramLimitExceeded: ERROR:  index row size 3088 exceeds maximum 2712 for index "contents__u_content"
11:55:40 web.1  | HINT:  Values larger than 1/3 of a buffer page cannot be indexed.
11:55:40 web.1  | Consider a function index of an MD5 hash of the value, or use full text indexing.
```
```
11:55:41 web.1  | PG::NotNullViolation: ERROR:  null value in column "visit_id" violates not-null constraint
11:55:41 web.1  | DETAIL:  Failing row contains (1c2ff3fe-1c6c-418e-86e2-b79d4f118a3c, null, 1, 1, 2, 1, a7d976b1-dd14-4d6b-9cdb-eca64b3eb34b, null, 200, 1061, 2022-05-24 16:55:41.164984+00).
```

The end user doesn't see this, again, but we see the visit id error in New Relic; update to this gem branch in `Gemfile`, `bundle install`, restart the server, hit the url again, and see that the above no longer occur.

There may still be some ROLLBACKs in the log, but as long as we don't see the error emitted, that seems like enough for now since we're really concerned with the noise from an insane param.

Key, we get this instead of the visit persistence failure:
```
12:01:59 web.1  |   Land::Visit Create (6.0ms)  INSERT INTO "land"."visits" ("visit_id", "cookie_id", "user_agent_id", "attribution_id", "ip_address", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING "visit_id"  [["visit_id", "a58996f8-9600-4871-94a6-b8a8c2da2a9a"], ["cookie_id", "de6b44d4-e128-42c2-b640-dbaac52cc280"], ["user_agent_id", 45], ["attribution_id", 5], ["ip_address", "127.0.0.1/32"], ["created_at", "2022-05-24 17:01:59.452725"], ["updated_at", "2022-05-24 17:01:59.452725"]]
12:01:59 web.1  |   TRANSACTION (0.7ms)  COMMIT
```

It didn't seem worth dropping and recreating indices with MD5 hashing just to handle this ... but since these are on the lookup gem tables, there's a custom migration method to create the tables, so I didn't change up the schema to do that for future consumers either. Just didn't seem worth it to tangle with the danger of complicating the migrations for those lookups for the edge case here.