### PR TITLE
Update migrations to be conditional

### DIFF
--- a/db/migrate/20220914012158_add_indexes_to_events.rb
+++ b/db/migrate/20220914012158_add_indexes_to_events.rb
@@ -2,7 +2,7 @@ class AddIndexesToEvents < ActiveRecord::Migration[7.0]
   disable_ddl_transaction!
 
   def change
-    add_index "#{Land.config.schema}.events", :created_at, algorithm: :concurrently
-    add_index "#{Land.config.schema}.events", :pageview_id, algorithm: :concurrently
+    add_index "#{Land.config.schema}.events", :created_at, algorithm: :concurrently unless index_exists?("#{Land.config.schema}.events", :created_at)
+    add_index "#{Land.config.schema}.events", :pageview_id, algorithm: :concurrently unless index_exists?("#{Land.config.schema}.events", :pageview_id)
   end
 end


### PR DESCRIPTION
Now that these indexes have been run manually in production and staging, this PR checks to see if they exist and only applies them if they don't. 