### PR TITLE
4754 remove duplicate indexes in land db

### DIFF
--- a/db/migrate/20230508161536_remove_ad_type_index_on_attributions.rb
+++ b/db/migrate/20230508161536_remove_ad_type_index_on_attributions.rb
@@ -1,0 +1,5 @@
+class RemoveAdTypeIndexOnAttributions < ActiveRecord::Migration[7.0]
+  def change
+    remove_index 'land.attribtions', column: :ad_type_id if index_exists?('land.attribtions', :ad_type_id)
+  end
+end

--- a/db/migrate/20230508161718_remove_domain_id_index_on_referers.rb
+++ b/db/migrate/20230508161718_remove_domain_id_index_on_referers.rb
@@ -1,0 +1,5 @@
+class RemoveDomainIdIndexOnReferers < ActiveRecord::Migration[7.0]
+  def change
+    remove_index 'land.referers', column: :domain_id if index_exists?('land.referers', :domain_id)
+  end
+end

--- a/spec/internal/db/structure.sql
+++ b/spec/internal/db/structure.sql
@@ -17,6 +17,13 @@ CREATE SCHEMA land;
 
 
 --
+-- Name: public; Type: SCHEMA; Schema: -; Owner: -
+--
+
+-- *not* creating schema, since initdb creates it
+
+
+--
 -- Name: uuid-ossp; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -2423,13 +2430,6 @@ CREATE INDEX referers_attribution_id_idx ON land.referers USING btree (attributi
 
 
 --
--- Name: referers_domain_id_idx; Type: INDEX; Schema: land; Owner: -
---
-
-CREATE INDEX referers_domain_id_idx ON land.referers USING btree (domain_id);
-
-
---
 -- Name: referers_path_id_idx; Type: INDEX; Schema: land; Owner: -
 --
 
@@ -2899,6 +2899,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20201027042604'),
 ('20220428195358'),
 ('20220914012158'),
-('20230116162450');
+('20230116162450'),
+('20230508161536'),
+('20230508161718');
 
 


### PR DESCRIPTION
[Trello Card](https://trello.com/c/FPfvq4aG/4754-remove-duplicate-indexes-in-land-db)
- Branching off main there seemed to be a migration that had not been run: `db/migrate/20230308215104_add_raw_query_strings.rb` , trying to run it with my new migrations resulted in an error `PG::UndefinedTable: ERROR:  relation "visits" does not exist` so I just ran my 2 migrations individually. Not sure the cause or what the scoop is there
- Verify that the syntax for my two migrations is correct, I tried to copy other migrations in land and migrations for removing indexes in our other apps