### PR TITLE
4754 Remove duplicate indexes in Land DB

### DIFF
--- a/db/migrate/20230526200145_remove_ad_type_index_on_attributions.rb
+++ b/db/migrate/20230526200145_remove_ad_type_index_on_attributions.rb
@@ -1,0 +1,5 @@
+class RemoveAdTypeIndexOnAttributions < ActiveRecord::Migration[7.0]
+  def change
+    remove_index 'land.attribtions', column: :ad_type_id if index_exists?('land.attribtions', :ad_type_id)
+  end
+end

--- a/db/migrate/20230526200145_remove_ad_type_index_on_attributions.rb
+++ b/db/migrate/20230526200145_remove_ad_type_index_on_attributions.rb
@@ -1,5 +1,5 @@
 class RemoveAdTypeIndexOnAttributions < ActiveRecord::Migration[7.0]
   def change
-    remove_index 'land.attributions', column: :ad_type_id if index_exists?('land.attribtions', :ad_type_id)
+    remove_index 'land.attributions', column: :ad_type_id if index_exists?('land.attributions', :ad_type_id)
   end
 end

--- a/db/migrate/20230526200145_remove_ad_type_index_on_attributions.rb
+++ b/db/migrate/20230526200145_remove_ad_type_index_on_attributions.rb
@@ -1,5 +1,5 @@
 class RemoveAdTypeIndexOnAttributions < ActiveRecord::Migration[7.0]
   def change
-    remove_index 'land.attribtions', column: :ad_type_id if index_exists?('land.attribtions', :ad_type_id)
+    remove_index 'land.attributions', column: :ad_type_id if index_exists?('land.attribtions', :ad_type_id)
   end
 end

--- a/db/migrate/20230526200413_remove_domain_id_index_on_referers.rb
+++ b/db/migrate/20230526200413_remove_domain_id_index_on_referers.rb
@@ -1,0 +1,5 @@
+class RemoveDomainIdIndexOnReferers < ActiveRecord::Migration[7.0]
+  def change
+    remove_index 'land.referers', column: :domain_id if index_exists?('land.referers', :domain_id)
+  end
+end

--- a/spec/internal/db/structure.sql
+++ b/spec/internal/db/structure.sql
@@ -17,6 +17,13 @@ CREATE SCHEMA land;
 
 
 --
+-- Name: public; Type: SCHEMA; Schema: -; Owner: -
+--
+
+-- *not* creating schema, since initdb creates it
+
+
+--
 -- Name: uuid-ossp; Type: EXTENSION; Schema: -; Owner: -
 --
 
@@ -2284,6 +2291,13 @@ CREATE INDEX "index_land.events_on_created_at" ON land.events USING btree (creat
 
 
 --
+-- Name: index_land.events_on_pageview_id; Type: INDEX; Schema: land; Owner: -
+--
+
+CREATE INDEX "index_land.events_on_pageview_id" ON land.events USING btree (pageview_id);
+
+
+--
 -- Name: index_land.events_on_request_id; Type: INDEX; Schema: land; Owner: -
 --
 
@@ -2414,13 +2428,6 @@ CREATE UNIQUE INDEX query_strings__u_query_string ON land.query_strings USING bt
 --
 
 CREATE INDEX referers_attribution_id_idx ON land.referers USING btree (attribution_id);
-
-
---
--- Name: referers_domain_id_idx; Type: INDEX; Schema: land; Owner: -
---
-
-CREATE INDEX referers_domain_id_idx ON land.referers USING btree (domain_id);
 
 
 --
@@ -2894,6 +2901,10 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220428195358'),
 ('20220914012158'),
 ('20230116162450'),
-('20230308215104');
+('20230308215104'),
+('20230508161536'),
+('20230508161718'),
+('20230526200145'),
+('20230526200413');
 
 

--- a/spec/internal/db/structure.sql
+++ b/spec/internal/db/structure.sql
@@ -2025,13 +2025,6 @@ CREATE INDEX attributions_ad_group_id_idx ON land.attributions USING btree (ad_g
 
 
 --
--- Name: attributions_ad_type_id_idx; Type: INDEX; Schema: land; Owner: -
---
-
-CREATE INDEX attributions_ad_type_id_idx ON land.attributions USING btree (ad_type_id);
-
-
---
 -- Name: attributions_affiliate_id_idx; Type: INDEX; Schema: land; Owner: -
 --
 
@@ -2288,13 +2281,6 @@ CREATE UNIQUE INDEX http_methods__u_http_method ON land.http_methods USING btree
 --
 
 CREATE INDEX "index_land.events_on_created_at" ON land.events USING btree (created_at);
-
-
---
--- Name: index_land.events_on_pageview_id; Type: INDEX; Schema: land; Owner: -
---
-
-CREATE INDEX "index_land.events_on_pageview_id" ON land.events USING btree (pageview_id);
 
 
 --
@@ -2902,8 +2888,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20220914012158'),
 ('20230116162450'),
 ('20230308215104'),
-('20230508161536'),
-('20230508161718'),
 ('20230526200145'),
 ('20230526200413');
 


### PR DESCRIPTION
Trello card: [Remove duplicate indexes in Land DB](https://trello.com/c/FPfvq4aG/4754-remove-duplicate-indexes-in-land-db)

- green specs
- run `rails db:migate` to run migrations on your local machine
- I could use some feedback on how to test this, thank you!

Once this is merged, we can then pull the migrations into ADR for this card: 
[Pull in new land migrations for removing duplicate indexes](https://trello.com/c/TfPrHQO8/4702-pull-in-new-land-migrations-for-removing-duplicate-indexes)